### PR TITLE
Add a cell note to keep Google Colab session alive

### DIFF
--- a/launch_kokoro.ipynb
+++ b/launch_kokoro.ipynb
@@ -310,6 +310,14 @@
     "        print(\"\\n❌ Failed to start Kokoro API. Please check the logs above for details.\")\n",
     "        print(\"You might want to try running the cell again or check for any error messages.\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "new-cell",
+   "metadata": {},
+   "source": [
+    "To keep this Google Colab session alive, run the following JavaScript code in the browser console: `function ClickConnect() { console.log(\"Clicked on connect button\"); document.querySelector(\"colab-toolbar-button#connect\").click() } setInterval(ClickConnect, 60000)`"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Add a new markdown cell to the `launch_kokoro.ipynb` file to keep the Google Colab session alive.

* Add a new markdown cell at the end of the notebook with JavaScript code to keep the session alive.
* The JavaScript code clicks the connect button every 60 seconds to prevent the session from timing out.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kokoro-FastAPI-Colab/pull/1?shareId=257ff4f3-7e77-4957-8c76-bf442b21e434).