### PR TITLE
Add guide for creating a free custom static ngrok domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ Click the button below to open this project in Google Colab with T4 GPU accelera
 # Todo
 Use ngrok static domains
 
+## Guide for Creating a Free Custom Static Ngrok Domain, Creating a Free Account, and Getting the Auth Token
+
+### Step 1: Create a Free Ngrok Account
+1. Go to the [ngrok website](https://ngrok.com/).
+2. Click on the "Sign Up" button.
+3. Fill in the required information to create a free account.
+4. Verify your email address if required.
+
+### Step 2: Get Your Ngrok Auth Token
+1. Log in to your ngrok account.
+2. Go to the "Auth" section in the dashboard.
+3. Copy your auth token from the provided field.
+
+### Step 3: Create a Free Custom Static Ngrok Domain
+1. In the ngrok dashboard, go to the "Reserved" section.
+2. Click on "Reserve a Domain".
+3. Choose a subdomain name and reserve it.
+4. Your custom static ngrok domain will be something like `your-subdomain.ngrok.io`.
+
+### Step 4: Set Up Ngrok in the Notebook
+1. In the code cell at the top of this notebook, set the `NGROK_AUTH_TOKEN` variable to your auth token.
+2. Set the `NGROK_CUSTOM_DOMAIN` variable to your reserved custom domain (optional).
+3. Run the notebook to start the Kokoro FastAPI server with ngrok tunnel.
+
 ## License
 
 See the [LICENSE](LICENSE) file for details.

--- a/launch_kokoro.ipynb
+++ b/launch_kokoro.ipynb
@@ -318,6 +318,36 @@
    "source": [
     "To keep this Google Colab session alive, run the following JavaScript code in the browser console: `function ClickConnect() { console.log(\"Clicked on connect button\"); document.querySelector(\"colab-toolbar-button#connect\").click() } setInterval(ClickConnect, 60000)`"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "new-cell-guide",
+   "metadata": {},
+   "source": [
+    "## Guide for Creating a Free Custom Static Ngrok Domain, Creating a Free Account, and Getting the Auth Token\n",
+    "\n",
+    "### Step 1: Create a Free Ngrok Account\n",
+    "1. Go to the [ngrok website](https://ngrok.com/).\n",
+    "2. Click on the \"Sign Up\" button.\n",
+    "3. Fill in the required information to create a free account.\n",
+    "4. Verify your email address if required.\n",
+    "\n",
+    "### Step 2: Get Your Ngrok Auth Token\n",
+    "1. Log in to your ngrok account.\n",
+    "2. Go to the \"Auth\" section in the dashboard.\n",
+    "3. Copy your auth token from the provided field.\n",
+    "\n",
+    "### Step 3: Create a Free Custom Static Ngrok Domain\n",
+    "1. In the ngrok dashboard, go to the \"Reserved\" section.\n",
+    "2. Click on \"Reserve a Domain\".\n",
+    "3. Choose a subdomain name and reserve it.\n",
+    "4. Your custom static ngrok domain will be something like `your-subdomain.ngrok.io`.\n",
+    "\n",
+    "### Step 4: Set Up Ngrok in the Notebook\n",
+    "1. In the code cell at the top of this notebook, set the `NGROK_AUTH_TOKEN` variable to your auth token.\n",
+    "2. Set the `NGROK_CUSTOM_DOMAIN` variable to your reserved custom domain (optional).\n",
+    "3. Run the notebook to start the Kokoro FastAPI server with ngrok tunnel."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Add a guide for creating a free custom static ngrok domain, creating a free account, and getting the auth token.

* **launch_kokoro.ipynb**
  - Add a new markdown cell with a guide for creating a free custom static ngrok domain.
  - Add instructions for creating a free ngrok account and getting the auth token.

* **README.md**
  - Update the "Todo" section to include a guide for creating a free custom static ngrok domain.
  - Add instructions for creating a free ngrok account and getting the auth token.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kokoro-FastAPI-Colab/pull/2?shareId=60f1cd1b-c9c2-4df7-a5dc-0af1eda407b8).